### PR TITLE
Add instructions for Safari WebDriver to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The `scrape.py` script collects tweet ids. If you know a tweet's id number, you 
 ## Requirements
 
 - basic knowledge on how to use a terminal
+- Safari 10+ with 'Allow Remote Automation' option enabled in Safari's Develop menu to control Safari via WebDriver.
 - python3
   - to check, in your terminal, enter `python3`
   - if you don't have it, check YouTube for installation instructions


### PR DESCRIPTION
Just played around with this script. In order to use the Safari WebDriver (the default webdriver in this script), you either need to download the deprecated web extension from the Selenium website or upgrade to Safari 10, which has a [WebDriver built in](https://webkit.org/blog/6900/webdriver-support-in-safari-10/).

I updated the README to provide Safari 10 as a requirement so your script works without any more config that the Twitter API details.

Here's the link to the Safari Extension needed if you want to support Safari 9 and before: https://github.com/SeleniumHQ/selenium/wiki/SafariDriver

Alternatively, you could add instructions for changing the browser driver in `scrape.py` before running the script.

Thanks for the hard work on this!